### PR TITLE
chore: reproduce rollup "unresolved dependency" warning for tree-shaken deps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import * as someDep from "some-dep";
 
 export async function main() {
-  // someDep.useNone();
-  someDep.useOptionalPeer();
+  someDep.useNone();
+  // someDep.useOptionalPeer();
 }
 
 main();


### PR DESCRIPTION
```sh
$  pnpm build-rollup

> @ build-rollup /home/hiroshi/Downloads/repro-vite-preact-iso
> rollup -c


./src/index.js → dist/rollup...
(!) Unresolved dependencies
https://rollupjs.org/troubleshooting/#warning-treating-module-as-external-dependency
no-such-lib (imported by "node_modules/.pnpm/file+some-dep/node_modules/some-dep/index.js")
created dist/rollup in 36ms
```